### PR TITLE
Setting theme from the config

### DIFF
--- a/libraries/Template.php
+++ b/libraries/Template.php
@@ -92,6 +92,12 @@ class Template
 			// Let's use this obvious default
 			$this->_theme_locations = array(APPPATH . 'themes/');
 		}
+		
+		// Theme was set
+		if ($this->_theme)
+		{
+			$this->set_theme($this->_theme);
+		}
 
 		// If the parse is going to be used, best make sure it's loaded
 		if ($this->_parser_enabled === TRUE)


### PR DESCRIPTION
If a theme was defined in the config, it wasn't actually building the _theme_path value, which meant you still had to call set_theme() in your controller. This change calls the set_theme() method from initialize() if a theme value was passed.
