### PR TITLE
Updates to config language and default layout

### DIFF
--- a/config/template.php
+++ b/config/template.php
@@ -45,18 +45,18 @@ $config['title_separator'] = ' | ';
 
 /*
 |--------------------------------------------------------------------------
-| Theme
+| Layout
 |--------------------------------------------------------------------------
 |
 | Which layout file should be used? When combined with theme it will be a layout file in that theme
 |
-| Change to 'main' to get /application/views/main.php
+| Change to 'main' to get /application/views/layouts/main.php
 |
-|   Default: FALSE
+|   Default: 'default'
 |
 */
 
-$config['layout'] = FALSE;
+$config['layout'] = 'default';
 
 /*
 |--------------------------------------------------------------------------
@@ -75,7 +75,7 @@ $config['theme'] = '';
 
 /*
 |--------------------------------------------------------------------------
-| Theme
+| Theme Locations
 |--------------------------------------------------------------------------
 |
 | Where should we expect to see themes?


### PR DESCRIPTION
Updated the language for some of the documentation, which looks like it may have been copy/pasted from another spot. Changed default layout to 'default' in order to reflect the docs and minimize user confusion. Took me a while to figure out my my default layout wasn't being used until I manually specified it with the set_layout() function.
