### PR TITLE
add get_theme() to retrieve current theme

### DIFF
--- a/libraries/Template.php
+++ b/libraries/Template.php
@@ -373,6 +373,17 @@ class Template
 	}
 
 	/**
+	 * Get the current theme
+	 *
+	 * @access public
+	 * @return string	The current theme
+	 */
+	 public function get_theme()
+	 {
+	 	return $this->_theme;
+	 }
+
+	/**
 	 * Get the current theme path
 	 *
 	 * @access	public


### PR DESCRIPTION
Added get_theme() to easily get the current theme name since _theme is private. I couldn't find another way to do this but I may just be missing something.
