### PR TITLE
Fixed a build() issue and a tiny typo

### DIFF
--- a/libraries/Template.php
+++ b/libraries/Template.php
@@ -61,7 +61,7 @@ class Template
 			$this->initialize($config);
 		}
 
-		log_message('debug', 'Template class Initialized');
+		log_message('debug', 'Template Class Initialized');
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
Was having some trouble with getting text back as a string using build() - also displayed to the screen, but now works fine. Also updated the log_message in the constructor to fit in with other CI init messages.
