### PR TITLE
Tweaked Title Functionality

### DIFF
--- a/config/template.php
+++ b/config/template.php
@@ -45,6 +45,32 @@ $config['title_separator'] = ' | ';
 
 /*
 |--------------------------------------------------------------------------
+| Progressive Build Title
+|--------------------------------------------------------------------------
+|
+| Add successive calls to $this->template->title() to an array for combination later
+|
+|   Default: FALSE
+|
+*/
+
+$config['progressive_build_title'] = FALSE;
+
+/*
+|--------------------------------------------------------------------------
+| Reverse Title Order
+|--------------------------------------------------------------------------
+|
+| If progressive build is turned on, do we reverse the title order before rendering?
+|
+|   Default: TRUE
+|
+*/
+
+$config['reverse_title_order'] = TRUE;
+
+/*
+|--------------------------------------------------------------------------
 | Layout
 |--------------------------------------------------------------------------
 |

--- a/libraries/Template.php
+++ b/libraries/Template.php
@@ -24,7 +24,7 @@ class Template
 	private $_layout_subdir = ''; // Layouts and partials will exist in views/layouts
 	// but can be set to views/foo/layouts with a subdirectory
 
-	private $_title = '';
+	private $_title = array();
 	private $_metadata = array();
 
 	private $_partials = array();
@@ -205,7 +205,10 @@ class Template
 		}
 
 		// Output template variables to the template
-		$template['title']	= $this->_title;
+		if($this->_reverse_title_order){
+			$this->_title = array_reverse($this->_title);
+		}
+		$template['title']	= implode($this->_title_separator, $this->_title);
 		$template['breadcrumbs'] = $this->_breadcrumbs;
 		$template['metadata']	= implode("\n\t\t", $this->_metadata);
 		$template['partials']	= array();
@@ -281,7 +284,16 @@ class Template
 		if (func_num_args() >= 1)
 		{
 			$title_segments = func_get_args();
-			$this->_title = implode($this->_title_separator, $title_segments);
+
+			if($this->_progressive_build_title){
+				if(count($title_segments) > 1){
+					$this->_title = array_merge($this->_title, $title_segments);
+				} else {
+					$this->_title[] = $title_segments[0];
+				}
+			} else {
+				$this->_title = $title_segments;
+			}
 		}
 
 		return $this;
@@ -782,7 +794,7 @@ class Template
 		}
 
 		// Glue the title pieces together using the title separator setting
-		$title = humanize(implode($this->_title_separator, $title_parts));
+		$title[] = humanize(implode($this->_title_separator, $title_parts));
 
 		return $title;
 	}


### PR DESCRIPTION
I've added in the ability to call template->title() successively, each time building an array of title segments. This allows developers to add a global title and then build on that throughout the code.

This is a config option, turned off by default. This makes sure than anyone expecting it to behave the old way, still behaves that way.
